### PR TITLE
Updated to .NET 6 + small code tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:5.0
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
     steps:
       - checkout
       - run: dotnet restore

--- a/InfinityWorks.TechTest.Test/Controllers/RatingControllerTests.cs
+++ b/InfinityWorks.TechTest.Test/Controllers/RatingControllerTests.cs
@@ -15,11 +15,13 @@ namespace InfinityWorks.TechTest.Test.Controllers
         public async Task GetAsync_ReturnsAllAuthorities()
         {
             // Arrange
-            var authorityList = new FsaAuthorityList();
-            authorityList.Authorities = new List<FsaAuthority>
+            var authorityList = new FsaAuthorityList
             {
-                new FsaAuthority { Name = "authority1", LocalAuthorityId = 1 },
-                new FsaAuthority { Name = "authority2", LocalAuthorityId = 2 }
+                Authorities = new List<FsaAuthority>
+                {
+                    new FsaAuthority { Name = "authority1", LocalAuthorityId = 1 },
+                    new FsaAuthority { Name = "authority2", LocalAuthorityId = 2 }
+                }
             };
 
             var fsaClient = new Mock<IFsaClient>();

--- a/InfinityWorks.TechTest.Test/InfinityWorks.TechTest.Test.csproj
+++ b/InfinityWorks.TechTest.Test/InfinityWorks.TechTest.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/InfinityWorks.TechTest/InfinityWorks.TechTest.csproj
+++ b/InfinityWorks.TechTest/InfinityWorks.TechTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InfinityWorks.TechTest/Services/FSAClient.cs
+++ b/InfinityWorks.TechTest/Services/FSAClient.cs
@@ -1,9 +1,7 @@
 ﻿using InfinityWorks.TechTest.Model;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System;
 
 namespace InfinityWorks.TechTest.Services
 {

--- a/InfinityWorks.TechTest/Startup.cs
+++ b/InfinityWorks.TechTest/Startup.cs
@@ -20,7 +20,7 @@ namespace InfinityWorks.TechTest
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Latest);
+            services.AddMvc();
             services.AddHttpClient();
             services.AddSingleton<IFsaClient, FsaClient>();
         }
@@ -36,7 +36,6 @@ namespace InfinityWorks.TechTest
             {
                 app.UseHsts();
             }
-
 
             app.UseHttpsRedirection();
             app.UseRouting();

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-* .NET SDK 5.0
+* .NET SDK 6.0
 * Access to the internet
 * Suitable development environment
 


### PR DESCRIPTION
Can see CircleCI doesn't support .NET 6 for now, will mark ready to review once supported

- Updated projects to .NET 6
- Unused usings removed
- Removed Compatibility Enum as [marked as obsolete ](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.compatibilityversion?view=aspnetcore-6.0)
- General code tidy